### PR TITLE
Bump org.codehaus.mojo:build-helper-maven-plugin from 3.4.0 to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1389,7 +1389,7 @@ under the License.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.0</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
pr_rerun dependabot/maven/org.codehaus.mojo-build-helper-maven-plugin-3.5.0 to master