### PR TITLE
Bump org.webjars:swagger-ui from 5.10.3 to 5.11.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,7 +443,7 @@ under the License.
     <h2.version>2.2.224</h2.version>
 
     <swagger-core.version>2.2.20</swagger-core.version>
-    <swagger-ui.version>5.10.3</swagger-ui.version>
+    <swagger-ui.version>5.11.8</swagger-ui.version>
 
     <jquery-slimscroll.version>1.3.8</jquery-slimscroll.version>
     <jquery-cookie.version>1.4.1-1</jquery-cookie.version>


### PR DESCRIPTION
pr_rerun dependabot/maven/org.webjars-swagger-ui-5.11.8 to master