### PR TITLE
Bump org.codehaus.mojo:exec-maven-plugin from 3.1.1 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1650,7 +1650,7 @@ under the License.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.0</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
pr_rerun dependabot/maven/org.codehaus.mojo-exec-maven-plugin-3.2.0 to master