### PR TITLE
Bump jakarta.servlet:jakarta.servlet-api from 6.0.0 to 6.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -547,7 +547,7 @@ under the License.
       <dependency>
         <groupId>jakarta.servlet</groupId>
         <artifactId>jakarta.servlet-api</artifactId>
-        <version>6.0.0</version>
+        <version>6.1.0</version>
         <scope>provided</scope>
       </dependency>
 


### PR DESCRIPTION
pr_rerun dependabot/maven/jakarta.servlet-jakarta.servlet-api-6.1.0 to master